### PR TITLE
Check if langchain_compressor is defined prior to deletion

### DIFF
--- a/script.py
+++ b/script.py
@@ -78,8 +78,9 @@ def toggle_extension(_enable: bool):
         compressor_model = langchain_compressor.embeddings.client
         compressor_model.to(compressor_model._target_device)
     else:
-        if not params["cpu only"]:  # free some VRAM
-            del langchain_compressor.embeddings.client
+        if not params["cpu only"] and 'langchain_compressor' in globals():  # free some VRAM
+            if hasattr(langchain_compressor, 'embeddings'):
+                del langchain_compressor.embeddings.client
             torch.cuda.empty_cache()
     params.update({"enable": _enable})
 


### PR DESCRIPTION
When starting text-generation-webui with the LLM_Web_search extension enabled, as well as `cpu only` and `enable` set to false in settings.json, the module fails to load because `langchain_compressor` is not yet defined.

```
$ ./start_linux.sh 
/bin/sh: 2: /home/x0xxin/text-generation-webui/installer_files/env/etc/conda/activate.d/ocl-icd_activate.sh: [[: not found
16:01:09-715318 INFO     Starting Text generation web UI                                                                      
16:01:09-719198 WARNING  trust_remote_code is enabled. This is dangerous.                                                     
16:01:09-720969 INFO     Loading the extension "LLM_Web_search"                                                               
16:01:11-669191 ERROR    Failed to load the extension "LLM_Web_search".                                                       
Traceback (most recent call last):
  File "/home/x0xxin/text-generation-webui/modules/extensions.py", line 46, in load_extensions
    extension.setup()
  File "/home/x0xxin/text-generation-webui/extensions/LLM_Web_search/script.py", line 62, in setup
    toggle_extension(params["enable"])
  File "/home/x0xxin/text-generation-webui/extensions/LLM_Web_search/script.py", line 82, in toggle_extension
    del langchain_compressor.embeddings.client
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'embeddings'
```
This PR attempts to resolve that issue by first checking if `langchain_compressor` is defined prior to attempting to delete it. It will still empty the torch cuda cache regardless of whether `langchain_compressor` is defined.