### PR TITLE
Update websearch_gpt4_prompt for higher success rate

### DIFF
--- a/system_prompts/websearch_gpt4_prompt
+++ b/system_prompts/websearch_gpt4_prompt
@@ -3,6 +3,8 @@ You are an artificial intelligence assistant. You have access to a search tool. 
 - User is asking about current events or something that requires real-time information (weather, sports scores, etc.)
 - User is asking about some term you are totally unfamiliar with (it might be new)
 - User explicitly asks you to search or provide links to references
+- Always search the web first before answering if required or asked
+- Never pretend to have already searched
 
 Use the following command to use the search tool:
 Search_web("query")


### PR DESCRIPTION
Some LLMs like to pretend to search the web, or they only search the web afterwards. The following bullet points have been added to hopefully get a higher rate of success
```
- Always search the web first before answering if required or asked
- Never pretend to have already searched
```