### PR TITLE
Enable Multiple searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ information about extensions.
 ## Usage
 
 Search queries are extracted from the model's output using a regular expression. This is made easier by prompting the model
-to use a fixed search command (see `system_prompts/` for example prompts).   
-Currently, only a single search query per model chat message is supported.
+to use a fixed search command (see `system_prompts/` for example prompts).
 
 An example workflow of using this extension could be:
 1. Load a model

--- a/script.js
+++ b/script.js
@@ -1,16 +1,16 @@
 var generate_button = document.getElementById("Generate");
-generate_button.insertAdjacentHTML("afterend", '<div style="position:relative;"> <label style="color:#8b8b8b;white-space:nowrap;position:absolute;top:8px;right:0px;"><input type="checkbox" id="force-search" name="accept">  Force web search </label> </div>');
+generate_button.insertAdjacentHTML("afterend", '<div style="position:relative;"> <label style="color:#8b8b8b;white-space:nowrap;position:absolute;right:0px;"><input type="checkbox" id="force-search" name="accept">  Force web search </label> </div>');
 generate_button.style.setProperty("position", "relative");
-generate_button.style.setProperty("top", "15px");
+generate_button.style.setProperty("top", "10px");
 generate_button.style.setProperty("margin-left", "-10px");
 
 var stop_button = document.getElementById("stop");
 stop_button.style.setProperty("position", "relative");
-stop_button.style.setProperty("top", "15px");
+stop_button.style.setProperty("top", "10px");
 stop_button.style.setProperty("margin-left", "-10px");
 
-var chat_tab = document.getElementById("chat-tab");
-chat_tab.style.marginTop = "-10px";
+var chat_input = document.getElementById("chat-input");
+chat_input.style.marginBottom = "5px";
 
 var checkbox = document.getElementById("force-search");
 var gradio_force_search_checkbox = document.getElementById("Force-search-checkbox").children[1].firstChild;

--- a/script.py
+++ b/script.py
@@ -506,7 +506,7 @@ def custom_generate_reply(question, original_question, seed, state, stopping_str
         if not display_results:
             update_history = f"{reply}\n{update_history}"
     else:
-        if recursive_call:
+        if recursive_call and not display_search_results:
             update_history = f"{reply}\n{update_history}"
 
 
@@ -576,4 +576,5 @@ def history_modifier(history):
         # concatenation of all recursive searches and their model completions, which *do* contain the full results.
         history["internal"][-1][-1] = update_history
         update_history = ""
+    print(history["internal"])
     return history

--- a/script.py
+++ b/script.py
@@ -3,6 +3,7 @@ import re
 import json
 import os
 from datetime import datetime
+from collections import defaultdict
 
 import gradio as gr
 import torch
@@ -50,7 +51,8 @@ params = {
 custom_system_message_filename = None
 extension_path = os.path.dirname(os.path.abspath(__file__))
 langchain_compressor = None
-update_history = ""
+update_history = defaultdict(str)
+chat_id = None
 force_search = False
 
 
@@ -171,6 +173,9 @@ def toggle_forced_search(value):
     global force_search
     force_search = value
 
+def update_chat_id(_id):
+    global chat_id
+    chat_id = _id
 
 def ui():
     """
@@ -272,7 +277,7 @@ def ui():
             sys_prompt_filename = gr.Text(label="Filename")
             sys_prompt_save_button = gr.Button("Save Custom system message")
             system_prompt_saved_success_elem = gr.HTML("", visible=False)
-            
+
     gr.Markdown(value='---')
     with gr.Accordion("Advanced settings", open=False):
         ensemble_weighting = gr.Slider(minimum=0, maximum=1, step=0.05, value=lambda: params["ensemble weighting"],
@@ -374,6 +379,9 @@ def ui():
     # A dummy checkbox to enable the actual "Force web search" checkbox to trigger a gradio event
     force_search_checkbox = gr.Checkbox(value=False, visible=False, elem_id="Force-search-checkbox")
     force_search_checkbox.change(toggle_forced_search, force_search_checkbox, None)
+
+    # Add event listener to "Past chats" radio menu to get the current unique chat ID
+    shared.gradio['unique_id'].change(update_chat_id, shared.gradio['unique_id'], None)
 
 
 def custom_generate_reply(question, original_question, seed, state, stopping_strings, is_chat, recursive_call=False):
@@ -504,10 +512,10 @@ def custom_generate_reply(question, original_question, seed, state, stopping_str
                 yield f"{original_model_reply}\n{new_reply}"
 
         if not display_results:
-            update_history = f"{reply}\n{update_history}"
+            update_history[state["unique_id"]] = f"{reply}\n{update_history[state['unique_id']]}"
     else:
         if recursive_call and not display_search_results:
-            update_history = f"{reply}\n{update_history}"
+            update_history[state["unique_id"]] = f"{reply}\n{update_history[state['unique_id']]}"
 
 
 
@@ -571,9 +579,9 @@ def history_modifier(history):
     :return:
     """
     global update_history
-    if update_history:
+    if update_history[chat_id]:
         # Replace the last reply in the internal history (which does not contain any search results) with the
         # concatenation of all recursive searches and their model completions, which *do* contain the full results.
-        history["internal"][-1][-1] = update_history
-        update_history = ""
+        history["internal"][-1][-1] = update_history[chat_id]
+        update_history[chat_id] = ""
     return history

--- a/script.py
+++ b/script.py
@@ -576,5 +576,4 @@ def history_modifier(history):
         # concatenation of all recursive searches and their model completions, which *do* contain the full results.
         history["internal"][-1][-1] = update_history
         update_history = ""
-    print(history["internal"])
     return history

--- a/script.py
+++ b/script.py
@@ -452,6 +452,7 @@ def custom_generate_reply(question, original_question, seed, state, stopping_str
             try:
                 for status_message in search_generator:
                     yield original_model_reply + f"\n*{status_message}*"
+                yield original_model_reply + "\n*Is typing...*"
                 search_results = docs_to_pretty_str(search_generator.retval)
             except Exception as exc:
                 exception_message = str(exc)

--- a/system_prompts/copilot_prompt
+++ b/system_prompts/copilot_prompt
@@ -1,7 +1,7 @@
 You are a state-of-the-art artificial intelligence assistant equipped with a comprehensive web search tool. Your mission is to provide accurate, up-to-date information and helpful answers to user queries. Here are the key guidelines:
 
 1. **Context-Aware Web Search:**
-   - When a user message contains relevant information or context suggesting the need for a web search, you will autonomously output the search command: `Search_web("query")`.
+   - When a user message contains relevant information or context suggesting the need for a web search, you will autonomously output the search command: Search_web("query")
    - Prioritize reliable sources and communicate findings clearly.
 
 2. **Fact-Driven Humility:**
@@ -13,4 +13,4 @@ You are a state-of-the-art artificial intelligence assistant equipped with a com
    - Extract information from search results to guide your answers.
    - Always end messages with an appropriate emoji to match the conveyed emotion.
 
-Remember the search command format: `Search_web("query")`.
+Remember the search command format: Search_web("query")


### PR DESCRIPTION
This PR gives the LLM the ability to trigger multiple web searches in a single conversation turn, thus allowing it to recover from temporary errors or iteratively research a topic.

Other small improvements:
- Add an *Is typing...* status message after control has returned to the main web UI and the search results are being processed. This matches the behavior of the main web UI when a long prompt is being processed.
- Change the JavaScript layout logic so that the chat column element can no longer extend into the tab bar. 
- Remove back ticks in the search command of the copilot_prompt 