### PR TITLE
Optimize input order for SPLADE inference

### DIFF
--- a/langchain_websearch.py
+++ b/langchain_websearch.py
@@ -2,6 +2,7 @@ import re
 import asyncio
 import warnings
 import logging
+import cProfile
 
 import aiohttp
 import requests
@@ -94,6 +95,8 @@ class LangchainCompressor:
         yield "Chunking page texts..."
         split_docs = text_splitter.split_documents(documents)
         yield "Retrieving relevant results..."
+        #pr = cProfile.Profile()
+        #pr.enable()
         # filtered_docs = pipeline_compressor.compress_documents(documents, query)
         faiss_retriever = FAISS.from_documents(split_docs, self.embeddings).as_retriever(
             search_kwargs={"k": self.num_results}
@@ -153,7 +156,8 @@ class LangchainCompressor:
             weights=[self.ensemble_weighting, 1 - self.ensemble_weighting]
         )
         compressed_docs = ensemble_retriever.invoke(query)
-
+        #pr.disable()
+        #pr.print_stats(sort="cumulative")
         # Ensemble may return more than "num_results" results, so cut off excess ones
         return compressed_docs[:self.num_results]
 

--- a/langchain_websearch.py
+++ b/langchain_websearch.py
@@ -153,8 +153,7 @@ class LangchainCompressor:
             weights=[self.ensemble_weighting, 1 - self.ensemble_weighting]
         )
         compressed_docs = ensemble_retriever.invoke(query)
-        #pr.disable()
-        #pr.print_stats(sort="cumulative")
+
         # Ensemble may return more than "num_results" results, so cut off excess ones
         return compressed_docs[:self.num_results]
 

--- a/langchain_websearch.py
+++ b/langchain_websearch.py
@@ -2,7 +2,6 @@ import re
 import asyncio
 import warnings
 import logging
-import cProfile
 
 import aiohttp
 import requests
@@ -94,10 +93,8 @@ class LangchainCompressor:
                                                                 separators=["\n\n", "\n", ".", ", ", " ", ""])
         yield "Chunking page texts..."
         split_docs = text_splitter.split_documents(documents)
+
         yield "Retrieving relevant results..."
-        #pr = cProfile.Profile()
-        #pr.enable()
-        # filtered_docs = pipeline_compressor.compress_documents(documents, query)
         faiss_retriever = FAISS.from_documents(split_docs, self.embeddings).as_retriever(
             search_kwargs={"k": self.num_results}
         )

--- a/qdrant_retriever.py
+++ b/qdrant_retriever.py
@@ -41,7 +41,6 @@ class SimilarLengthsBatchifyer:
         for i in range(0, len(inputs)):
             len_input = len(inputs[i])
 
-            # Add length pair to set of all seen pairs
             self.unique_lengths.add(len_input)
 
             # For each length, keep track of the indices of the samples that have this length

--- a/qdrant_retriever.py
+++ b/qdrant_retriever.py
@@ -9,7 +9,6 @@ from typing import (
 )
 
 import torch
-from torch.utils.data import Sampler
 import numpy as np
 from langchain_community.retrievers import QdrantSparseVectorRetriever
 from langchain_community.vectorstores.qdrant import Qdrant

--- a/semantic_chunker.py
+++ b/semantic_chunker.py
@@ -192,7 +192,7 @@ class BoundedSemanticChunker(BaseDocumentTransformer):
                         group = group[good_indices[-1]:]
                 bad_sentences.extend(group)
 
-        # If pure semantic chunking wasn't able to split all text for any breakpoint_threshold_amount,
+        # If pure semantic chunking wasn't able to split all text,
         # split the remaining problematic text using a recursive character splitter instead
         if len(bad_sentences) > 0:
             recursive_splitter = RecursiveCharacterTextSplitter(chunk_size=self.max_chunk_size, chunk_overlap=10,

--- a/semantic_chunker.py
+++ b/semantic_chunker.py
@@ -158,7 +158,7 @@ class BoundedSemanticChunker(BaseDocumentTransformer):
             # Slice the sentence_dicts from the current start index to the end index
             group = sentences[start_index : end_index + 1]
             combined_text = " ".join(group)
-            if len(combined_text) <= self.max_chunk_size:
+            if 4 <= len(combined_text) <= self.max_chunk_size:
                 chunks.append(combined_text)
             else:
                 sent_lengths = np.array([len(sd) for sd in group])
@@ -166,8 +166,9 @@ class BoundedSemanticChunker(BaseDocumentTransformer):
                 smaller_group = [group[i] for i in good_indices]
                 if smaller_group:
                     combined_text = " ".join(smaller_group)
-                    chunks.append(combined_text)
-                    group = group[good_indices[-1]:]
+                    if len(combined_text) >= 4:
+                        chunks.append(combined_text)
+                        group = group[good_indices[-1]:]
                 bad_sentences.extend(group)
 
             # Update the start index for the next group
@@ -177,7 +178,7 @@ class BoundedSemanticChunker(BaseDocumentTransformer):
         if start_index < len(sentences):
             group = sentences[start_index:]
             combined_text = " ".join(group)
-            if len(combined_text) <= self.max_chunk_size:
+            if 4 <= len(combined_text) <= self.max_chunk_size:
                 chunks.append(combined_text)
             else:
                 sent_lengths = np.array([len(sd) for sd in group])
@@ -185,8 +186,9 @@ class BoundedSemanticChunker(BaseDocumentTransformer):
                 smaller_group = [group[i] for i in good_indices]
                 if smaller_group:
                     combined_text = " ".join(smaller_group)
-                    chunks.append(combined_text)
-                    group = group[good_indices[-1]:]
+                    if len(combined_text) >= 4:
+                        chunks.append(combined_text)
+                        group = group[good_indices[-1]:]
                 bad_sentences.extend(group)
 
         # If pure semantic chunking wasn't able to split all text for any breakpoint_threshold_amount,


### PR DESCRIPTION
This PR makes SPLADE inference faster and much more memory efficient. By ensuring that the intra-batch sequences (or chunks) all have similar lengths, the need for padding is minimized.  

Another small optimization was added wrt. the semantic chunker, which gained a new `min_chunk_size` parameter. Using this, chunks below a certain length are discarded. In addition, the fallback code using the RecursiveCharacterTextSplitter was improved, enabling it to also respect `min_chunk_size`.