### PR TITLE
Dynamic SPLADE batch size

### DIFF
--- a/langchain_websearch.py
+++ b/langchain_websearch.py
@@ -153,8 +153,8 @@ class LangchainCompressor:
             retrievers=[compression_retriever, keyword_retriever],
             weights=[self.ensemble_weighting, 1 - self.ensemble_weighting]
         )
-
         compressed_docs = ensemble_retriever.invoke(query)
+
         # Ensemble may return more than "num_results" results, so cut off excess ones
         return compressed_docs[:self.num_results]
 

--- a/langchain_websearch.py
+++ b/langchain_websearch.py
@@ -18,8 +18,7 @@ from langchain_community.document_transformers import EmbeddingsRedundantFilter
 from langchain_community.retrievers import BM25Retriever
 from transformers import AutoTokenizer, AutoModelForMaskedLM
 import optimum.bettertransformer.transformation
-import pickle
-import cProfile
+
 try:
     from qdrant_client import QdrantClient, models
 except ImportError:
@@ -79,10 +78,8 @@ class LangchainCompressor:
 
     def retrieve_documents(self, query: str, url_list: list[str]) -> list[Document]:
         yield "Downloading webpages..."
-        #html_url_tupls = zip(asyncio.run(async_fetch_urls(url_list)), url_list)
-        #html_url_tupls = [(content, url) for content, url in html_url_tupls if content is not None]
-        with open("llama_html_tups", "rb") as f:
-            html_url_tupls = pickle.load(f)
+        html_url_tupls = zip(asyncio.run(async_fetch_urls(url_list)), url_list)
+        html_url_tupls = [(content, url) for content, url in html_url_tupls if content is not None]
         if not html_url_tupls:
             return []
 
@@ -98,8 +95,6 @@ class LangchainCompressor:
         split_docs = text_splitter.split_documents(documents)
 
         yield "Retrieving relevant results..."
-        pr = cProfile.Profile()
-        pr.enable()
         faiss_retriever = FAISS.from_documents(split_docs, self.embeddings).as_retriever(
             search_kwargs={"k": self.num_results}
         )
@@ -158,8 +153,7 @@ class LangchainCompressor:
             weights=[self.ensemble_weighting, 1 - self.ensemble_weighting]
         )
         compressed_docs = ensemble_retriever.invoke(query)
-        pr.disable()
-        pr.print_stats(sort="cumulative")
+
         # Ensemble may return more than "num_results" results, so cut off excess ones
         return compressed_docs[:self.num_results]
 

--- a/langchain_websearch.py
+++ b/langchain_websearch.py
@@ -153,6 +153,7 @@ class LangchainCompressor:
             retrievers=[compression_retriever, keyword_retriever],
             weights=[self.ensemble_weighting, 1 - self.ensemble_weighting]
         )
+
         compressed_docs = ensemble_retriever.invoke(query)
         # Ensemble may return more than "num_results" results, so cut off excess ones
         return compressed_docs[:self.num_results]

--- a/langchain_websearch.py
+++ b/langchain_websearch.py
@@ -19,6 +19,7 @@ from langchain_community.document_transformers import EmbeddingsRedundantFilter
 from langchain_community.retrievers import BM25Retriever
 from transformers import AutoTokenizer, AutoModelForMaskedLM
 import optimum.bettertransformer.transformation
+
 try:
     from qdrant_client import QdrantClient, models
 except ImportError:

--- a/qdrant_retriever.py
+++ b/qdrant_retriever.py
@@ -166,8 +166,8 @@ class MyQdrantSparseVectorRetriever(QdrantSparseVectorRetriever):
     ):
         client = cast(QdrantClient, self.client)
 
-        # Remove duplicate texts
-        text_to_metadata = {texts[i]: metadatas[i] for i in range(len(texts))}
+        # Remove duplicate and empty texts
+        text_to_metadata = {texts[i]: metadatas[i] for i in range(len(texts)) if len(texts[i]) > 0}
         texts = list(text_to_metadata.keys())
         metadatas = list(text_to_metadata.values())
 

--- a/qdrant_retriever.py
+++ b/qdrant_retriever.py
@@ -32,8 +32,8 @@ class SimilarLengthsBatchifyer:
     of equal/similar length together to minimize the need for padding within a batch.
     """
     def __init__(self, batch_size, inputs, max_padding_len=10):
-        # Remember batch size and number of samples
-        self.batch_size, self.num_samples = batch_size, len(inputs)
+        # Remember number of samples
+        self.num_samples = len(inputs)
 
         self.unique_lengths = set()
         self.length_to_sample_indices = {}
@@ -52,8 +52,8 @@ class SimilarLengthsBatchifyer:
 
         # Use a dynamic batch size to speed up inference at a constant VRAM usage
         self.unique_lengths = sorted(list(self.unique_lengths))
-        max_chars_per_batch = self.unique_lengths[-1] * self.batch_size
-        self.length_to_batch_size = {length: int(max_chars_per_batch / (length * self.batch_size)) * self.batch_size for length in self.unique_lengths}
+        max_chars_per_batch = self.unique_lengths[-1] * batch_size
+        self.length_to_batch_size = {length: int(max_chars_per_batch / (length * batch_size)) * batch_size for length in self.unique_lengths}
 
         # Merge samples of similar lengths in those cases where the amount of samples
         # of a particular length is < dynamic batch size

--- a/script.py
+++ b/script.py
@@ -471,7 +471,7 @@ def custom_generate_reply(question, original_question, seed, state, stopping_str
                     reply += search_results
                 else:
                     reply += f"\nThe search tool did not return any results."
-            reply += "```"
+            reply += "```\n"
             if display_search_results:
                 yield reply
             break
@@ -507,7 +507,7 @@ def custom_generate_reply(question, original_question, seed, state, stopping_str
         for new_reply in custom_generate_reply(new_question, new_question, seed, state,
                                                stopping_strings, is_chat=is_chat, recursive_call=True):
             if display_results:
-                yield f"{reply}\n{new_reply}"
+                yield f"{reply}{new_reply}"
             else:
                 yield f"{original_model_reply}\n{new_reply}"
 


### PR DESCRIPTION
This PR implements dynamic batch sizing, which enables significantly faster SPLADE inference at a constant VRAM usage, without increasing the max. VRAM required during inference. In addition, the SPLADE models are now finally loaded in FP16, something that should have been done from the very start.

#### How Dynamic Batch sizing works
First, the max. amount of characters that will be input to the SPLADE document encoder is calculated as the max. chunk size multiplied by the original batch size. Subsequently, the batch sizes for all smaller chunk sizes are increased proportionally, so that that the amount of characters per batch remains as constant as possible during inference.   
The result is a constant maximum VRAM usage with faster inference, instead of a slower inference with a spike to the maximum vram usage once the max. amount of characters per batch is reached.