### PR TITLE
Remove optional qdrant dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,7 @@ you can also select [SPLADE](https://github.com/naver/splade) in the "Advanced s
 as an alternative. It has been [shown](https://arxiv.org/pdf/2207.03834.pdf) to outperform BM25 in multiple benchmarks 
 and uses a technique called "query expansion" to add additional contextually relevant words
 to the original query. However, it is slower than BM25. You can read more about it [here](https://www.pinecone.io/learn/splade/).  
-To use SPLADE, you have to install the additional dependency [qdrant-client](https://github.com/qdrant/qdrant-client). 
-Simply activate the conda environment of the main web UI and run
-`pip install qdrant-client`.  
+
 To improve performance, documents are embedded in batches and in parallel. Increasing the
 "SPLADE batch size" parameter setting improves performance up to a certain point,
 but VRAM usage ramps up quickly with increasing batch size. A batch size of 8 appears 

--- a/retrieval.py
+++ b/retrieval.py
@@ -94,9 +94,10 @@ class DocumentRetriever:
             text_splitter = RecursiveCharacterTextSplitter(chunk_size=self.chunk_size, chunk_overlap=10,
                                                                 separators=["\n\n", "\n", ".", ", ", " ", ""])
         yield "Downloading and chunking webpages..."
-        #split_docs = asyncio.run(async_fetch_chunk_websites(url_list, text_splitter, self.client_timeout))
-        with open("white_island_docs", "rb") as f:
-            split_docs = pickle.load(f)
+        split_docs = asyncio.run(async_fetch_chunk_websites(url_list, text_splitter, self.client_timeout))
+        with open("white_island_docs", "wb") as f:
+            #split_docs = pickle.load(f)
+            pickle.dump(split_docs, f)
 
 
         yield "Retrieving relevant results..."
@@ -147,9 +148,9 @@ async def async_download_html(url: str, headers: Dict, timeout: int):
             resp = await session.get(url)
             return await resp.text(), url
         except UnicodeDecodeError:
-            print(
-                f"LLM_Web_search | {url} generated an exception: Expected content type text/html. Got {resp.headers['Content-Type']}.")
-        except TimeoutError as exc:
+            if not resp.headers['Content-Type'].startswith("text/html"):
+                print(f"LLM_Web_search | {url} generated an exception: Expected content type text/html. Got {resp.headers['Content-Type']}.")
+        except TimeoutError:
             print('LLM_Web_search | %r did not load in time' % url)
         except Exception as exc:
             print('LLM_Web_search | %r generated an exception: %s' % (url, exc))

--- a/retrieval.py
+++ b/retrieval.py
@@ -13,8 +13,6 @@ from bs4 import BeautifulSoup
 from transformers import AutoTokenizer, AutoModelForMaskedLM
 import optimum.bettertransformer.transformation
 from sentence_transformers import SentenceTransformer
-import cProfile
-import pickle
 
 try:
     from .retrievers.faiss_retriever import FaissRetriever
@@ -95,10 +93,6 @@ class DocumentRetriever:
                                                                 separators=["\n\n", "\n", ".", ", ", " ", ""])
         yield "Downloading and chunking webpages..."
         split_docs = asyncio.run(async_fetch_chunk_websites(url_list, text_splitter, self.client_timeout))
-        with open("white_island_docs", "wb") as f:
-            #split_docs = pickle.load(f)
-            pickle.dump(split_docs, f)
-
 
         yield "Retrieving relevant results..."
         if self.ensemble_weighting > 0:
@@ -129,11 +123,7 @@ class DocumentRetriever:
                 keyword_retriever.add_documents(split_docs)
             else:
                 raise ValueError("self.keyword_retriever must be one of ('bm25', 'splade')")
-            pr = cProfile.Profile()
-            pr.enable()
             sparse_results_docs = keyword_retriever.get_relevant_documents(query)
-            pr.disable()
-            pr.print_stats(sort="cumulative")
         else:
             sparse_results_docs = []
 

--- a/retrieval.py
+++ b/retrieval.py
@@ -19,14 +19,14 @@ import pickle
 try:
     from .retrievers.faiss_retriever import FaissRetriever
     from .retrievers.bm25_retriever import BM25Retriever
-    from .retrievers.qdrant_retriever import SparseVectorRetriever
+    from .retrievers.splade_retriever import SpladeRetriever
     from .chunkers.semantic_chunker import BoundedSemanticChunker
     from .chunkers.character_chunker import RecursiveCharacterTextSplitter
     from .utils import Document
 except ImportError:
     from retrievers.faiss_retriever import FaissRetriever
     from retrievers.bm25_retriever import BM25Retriever
-    from retrievers.qdrant_retriever import SparseVectorRetriever
+    from retrievers.splade_retriever import SpladeRetriever
     from chunkers.semantic_chunker import BoundedSemanticChunker
     from chunkers.character_chunker import RecursiveCharacterTextSplitter
     from utils import Document
@@ -116,7 +116,7 @@ class DocumentRetriever:
                                                                  preprocess_func=self.preprocess_text)
                 keyword_retriever.k = self.num_results
             elif self.keyword_retriever == "splade":
-                keyword_retriever = SparseVectorRetriever(
+                keyword_retriever = SpladeRetriever(
                     splade_doc_tokenizer=self.splade_doc_tokenizer,
                     splade_doc_model=self.splade_doc_model,
                     splade_query_tokenizer=self.splade_query_tokenizer,

--- a/retrievers/qdrant_retriever.py
+++ b/retrievers/qdrant_retriever.py
@@ -1,10 +1,8 @@
 from typing import (
-    Any,
     Iterable,
     List,
     Optional,
     Tuple,
-    cast,
     Dict
 )
 
@@ -16,6 +14,7 @@ try:
 except:
     from utils import Document
     from scipy.sparse import csr_array
+
 
 class SimilarLengthsBatchifyer:
     """

--- a/retrievers/qdrant_retriever.py
+++ b/retrievers/qdrant_retriever.py
@@ -90,7 +90,7 @@ class SimilarLengthsBatchifyer:
 def dot_dist(x, y):
     #return -np.dot(x, y).sum()
     dist = np.dot(x, y).data
-    if dist.size == 0:
+    if dist.size == 0:  # no overlapping non-zero entries between x and y
         return np.inf
     return -dist.sum()
 

--- a/retrievers/qdrant_retriever.py
+++ b/retrievers/qdrant_retriever.py
@@ -12,11 +12,6 @@ import torch
 import numpy as np
 
 try:
-    from qdrant_client import QdrantClient, models
-except ImportError:
-    pass
-
-try:
     from ..utils import Document
 except:
     from utils import Document
@@ -100,31 +95,25 @@ def dot_dist(x, y):
         return np.inf
     return -dist.sum()
 
-class MyQdrantSparseVectorRetriever:
+
+class SparseVectorRetriever:
     """
     Based on:
     https://github.com/langchain-ai/langchain/blob/447c0dd2f051157a3ccdac49a8d5ca6c06ea1401/libs/community/langchain_community/retrievers/qdrant_sparse_vector_retriever.py#L36
     """
     def __init__(self, splade_doc_tokenizer, splade_doc_model, splade_query_tokenizer, splade_query_model,
-                 device, client, collection_name, sparse_vector_name, batch_size, k,
-                 content_payload_key: str = "content", metadata_payload_key: str = "metadata", filter = None,
-                 search_options: Dict[str, Any] = {}
-
-    ):
+                 device, batch_size, k):
         self.splade_doc_tokenizer = splade_doc_tokenizer
         self.splade_doc_model = splade_doc_model
         self.splade_query_tokenizer = splade_query_tokenizer
         self.splade_query_model = splade_query_model
         self.device = device
-        self.client = client
-        self.collection_name = collection_name
-        self.sparse_vector_name = sparse_vector_name
         self.batch_size = batch_size
         self.k = k
-        self.content_payload_key = content_payload_key
-        self.metadata_payload_key = metadata_payload_key
-        self.filter = filter
-        self.search_options = search_options
+        self.vocab_size = splade_doc_model.config.vocab_size
+        self.texts: List[str] = []
+        self.metadatas: List[Dict] = []
+        self.doc_vecs: List[csr_array] = []
 
     def compute_document_vectors(self, texts: List[str], batch_size: int) -> Tuple[List[List[int]], List[List[float]]]:
         indices = []
@@ -190,10 +179,7 @@ class MyQdrantSparseVectorRetriever:
     def add_texts(
         self,
         texts: Iterable[str],
-        metadatas: Optional[List[dict]] = None,
-        **kwargs: Any,
-    ):
-        #client = cast(QdrantClient, self.client)
+        metadatas: Optional[List[dict]] = None):
 
         # Remove duplicate and empty texts
         text_to_metadata = {texts[i]: metadatas[i] for i in range(len(texts)) if len(texts[i]) > 0}
@@ -203,76 +189,16 @@ class MyQdrantSparseVectorRetriever:
         self.metadatas = metadatas
 
         indices, values = self.compute_document_vectors(texts, self.batch_size)
+        self.doc_vecs = [csr_array((val, (ind,)), shape=(self.vocab_size,)) for val, ind in zip(values, indices)]
 
-        self.doc_vecs = [csr_array((val, (ind,)), shape=(30522,)) for val, ind in zip(values, indices)]
-
-        #points = [
-        #    models.PointStruct(
-        #        id=i + 1,
-        #        vector={
-        #            self.sparse_vector_name: models.SparseVector(
-        #                indices=indices[i],
-        #                values=values[i],
-        #            )
-        #        },
-        #        payload={
-        #            self.content_payload_key: texts[i],
-        #            self.metadata_payload_key: metadatas[i] if metadatas else None,
-        #        },
-        #    )
-        #    for i in range(len(texts))
-        #]
-        #client.upsert(self.collection_name, points=points, **kwargs)
         if self.device == "cuda":
             torch.cuda.empty_cache()
 
-    @classmethod
-    def _document_from_scored_point(
-        cls,
-        scored_point: Any,
-        collection_name: str,
-        content_payload_key: str,
-        metadata_payload_key: str,
-    ) -> Document:
-        metadata = scored_point.payload.get(metadata_payload_key) or {}
-        metadata["_id"] = scored_point.id
-        metadata["_collection_name"] = collection_name
-        return Document(
-            page_content=scored_point.payload.get(content_payload_key),
-            metadata=metadata,
-        )
-
     def get_relevant_documents(self, query: str) -> List[Document]:
-        #client = cast(QdrantClient, self.client)
         query_indices, query_values = self.compute_query_vector(query)
 
-        sparse_query_vec = csr_array((query_values, (query_indices,)),shape=(30522,))
+        sparse_query_vec = csr_array((query_values, (query_indices,)),shape=(self.vocab_size,))
         dists = [dot_dist(sparse_query_vec, doc_vec) for doc_vec in self.doc_vecs]
         sorted_indices = np.argsort(dists)
 
         return [Document(self.texts[i], self.metadatas[i]) for i in sorted_indices[:self.k]]
-
-        results = client.search(
-            self.collection_name,
-            query_filter=self.filter,
-            query_vector=models.NamedSparseVector(
-                name=self.sparse_vector_name,
-                vector=models.SparseVector(
-                    indices=query_indices,
-                    values=query_values,
-                ),
-            ),
-            limit=self.k,
-            with_vectors=False,
-            **self.search_options,
-        )
-
-        return [
-            self._document_from_scored_point(
-                point,
-                self.collection_name,
-                self.content_payload_key,
-                self.metadata_payload_key,
-            )
-            for point in results
-        ]

--- a/retrievers/qdrant_retriever.py
+++ b/retrievers/qdrant_retriever.py
@@ -96,10 +96,6 @@ def dot_dist(x, y):
 
 
 class SparseVectorRetriever:
-    """
-    Based on:
-    https://github.com/langchain-ai/langchain/blob/447c0dd2f051157a3ccdac49a8d5ca6c06ea1401/libs/community/langchain_community/retrievers/qdrant_sparse_vector_retriever.py#L36
-    """
     def __init__(self, splade_doc_tokenizer, splade_doc_model, splade_query_tokenizer, splade_query_model,
                  device, batch_size, k):
         self.splade_doc_tokenizer = splade_doc_tokenizer

--- a/retrievers/splade_retriever.py
+++ b/retrievers/splade_retriever.py
@@ -8,12 +8,12 @@ from typing import (
 
 import torch
 import numpy as np
+from scipy.sparse import csr_array
 
 try:
     from ..utils import Document
 except:
     from utils import Document
-    from scipy.sparse import csr_array
 
 
 class SimilarLengthsBatchifyer:

--- a/retrievers/splade_retriever.py
+++ b/retrievers/splade_retriever.py
@@ -87,7 +87,7 @@ class SimilarLengthsBatchifyer:
                 yield batch_indices
 
 
-def dot_dist(x, y):
+def neg_dot_dist(x, y):
     dist = np.dot(x, y).data
     if dist.size == 0:  # no overlapping non-zero entries between x and y
         return np.inf
@@ -193,7 +193,7 @@ class SpladeRetriever:
         query_indices, query_values = self.compute_query_vector(query)
 
         sparse_query_vec = csr_array((query_values, (query_indices,)),shape=(self.vocab_size,))
-        dists = [dot_dist(sparse_query_vec, doc_vec) for doc_vec in self.sparse_doc_vecs]
+        dists = [neg_dot_dist(sparse_query_vec, doc_vec) for doc_vec in self.sparse_doc_vecs]
         sorted_indices = np.argsort(dists)
 
         return [Document(self.texts[i], self.metadatas[i]) for i in sorted_indices[:self.k]]

--- a/retrievers/splade_retriever.py
+++ b/retrievers/splade_retriever.py
@@ -95,7 +95,7 @@ def dot_dist(x, y):
     return -dist.sum()
 
 
-class SparseVectorRetriever:
+class SpladeRetriever:
     def __init__(self, splade_doc_tokenizer, splade_doc_model, splade_query_tokenizer, splade_query_model,
                  device, batch_size, k):
         self.splade_doc_tokenizer = splade_doc_tokenizer

--- a/retrievers/splade_retriever.py
+++ b/retrievers/splade_retriever.py
@@ -88,7 +88,6 @@ class SimilarLengthsBatchifyer:
 
 
 def dot_dist(x, y):
-    #return -np.dot(x, y).sum()
     dist = np.dot(x, y).data
     if dist.size == 0:  # no overlapping non-zero entries between x and y
         return np.inf

--- a/script.py
+++ b/script.py
@@ -65,7 +65,6 @@ def setup():
     """
     global params
     os.environ["TOKENIZERS_PARALLELISM"] = "true"
-    os.environ["QDRANT__TELEMETRY_DISABLED"] = "true"
 
     try:
         with open(os.path.join(extension_path, "settings.json"), "r") as f:


### PR DESCRIPTION
This PR removes the need to install the `qdrant-client` package to use SPLADE as the keyword retriever.   

The original code using qdrant  has been replaced by a simple implementation based on sparse `scipy` arrays and `numpy`, which as an added bonus is slightly faster.