### PR TITLE
Remove ddgs dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 ![unit tests](https://github.com/mamei16/LLM_Web_search/actions/workflows/unit_tests.yml/badge.svg?branch=main)
 
 This project gives local LLMs the ability to search the web by outputting a specific
-command. Once the command has been found in the model output using a regular expression,
-[duckduckgo-search](https://pypi.org/project/duckduckgo-search/)
-is used to search the web and return a number of result pages. Finally, an
+command. Once the command has been found in the model output using a regular expression, a web search is issued, returning a number of result pages. Finally, an
 ensemble of a dense embedding model and 
 [Okapi BM25](https://en.wikipedia.org/wiki/Okapi_BM25) (Or alternatively, [SPLADE](https://github.com/naver/splade))
 is used to extract the relevant parts (if any) of each web page in the search results
@@ -49,17 +47,6 @@ title "LLM Web Search" should be visible in the web UI.
 See https://github.com/oobabooga/text-generation-webui/wiki/07-%E2%80%90-Extensions for more
 information about extensions.
 
-### Updating DuckDuckGo Search Python Package
-
-The `duckduckgo-search` python package is now called `ddgs` and may now also retrieve results from other search engines, such as Bing. If you're fine with this, you can try to avoid the `202 Ratelimit` exceptions that regularly appear when using the old `duckduckgo-search` by manually installing `ddgs` before using this extension, by using the following steps:
-1. Run the appropriate `cmd_` script inside the text-generation-webui folder
-2. Run the command:
-   
-```
-pip install ddgs
-```
-
-If you choose to use SearXNG as the search engine backend, you of course won't need to install `ddgs`.
 
 ## Usage
 
@@ -103,8 +90,6 @@ Download_webpage\("(.*)"\)
 
 ### DuckDuckGo
 This is the default web search backend. 
-
-Note that the `duckduckgo-search` package that was used for this search backend  changed name to `ddgs` and may now also retrieve results from other search engines such as Bing (see the [Installation section](#installation))
 
 ### SearXNG
 

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,6 @@ dependencies:
 - pip
 - faiss-cpu=1.10.0
 - pip:
-  - duckduckgo_search==8.0.4
   - beautifulsoup4==4.13.4
   - unstructured==0.16.23
   - rank_bm25==0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 faiss-cpu==1.10.0
-duckduckgo_search==8.0.4
 beautifulsoup4==4.13.4
 unstructured==0.16.23
 rank_bm25==0.2.2

--- a/script.py
+++ b/script.py
@@ -530,7 +530,6 @@ def custom_generate_reply(question, original_question, state, stopping_strings, 
                 search_generator = Generator(retrieve_from_duckduckgo(search_term,
                                                                       document_retriever,
                                                                       max_search_results,
-                                                                      instant_answers,
                                                                       simple_search))
             else:
                 search_generator = Generator(retrieve_from_searxng(search_term,

--- a/test_basics.py
+++ b/test_basics.py
@@ -13,7 +13,7 @@ class MyTestCase(unittest.TestCase):
 
     def test_basic_search(self):
         gen = Generator(retrieve_from_duckduckgo("How much does a LLama weigh?",
-                                                 self.document_retriever, instant_answers=True, max_results=5))
+                                                 self.document_retriever, max_results=5))
         status_messages = list(gen)
         self.assertEqual(status_messages[0], "Getting results from DuckDuckGo...")
         self.assertEqual(status_messages[1], "Downloading and chunking webpages...")
@@ -24,6 +24,7 @@ class MyTestCase(unittest.TestCase):
 
         for document in search_result_dict:
             self.assertIsNotNone(document.page_content)
+            self.assertNotEqual(document.page_content, "")
             self.assertIsNotNone(document.metadata['source'])
 
 

--- a/utils.py
+++ b/utils.py
@@ -11,14 +11,6 @@ import torch
 import numpy as np
 from sentence_transformers import SentenceTransformer, quantize_embeddings
 from sentence_transformers.util import batch_to_device, truncate_embeddings
-try:
-    from ddgs import DDGS
-    from ddgs.utils import json_loads
-    from ddgs.exceptions import DDGSException as DuckDuckGoSearchException
-except ModuleNotFoundError:
-    from duckduckgo_search import DDGS
-    from duckduckgo_search.utils import json_loads
-    from duckduckgo_search.exceptions import DuckDuckGoSearchException
 
 
 @dataclass
@@ -330,52 +322,6 @@ def sync_device(device: torch.device):
         torch.xpu.synchronize(device)
     else:
         warnings.warn("Device type does not match 'cuda', 'xpu' or 'mps'. Not synchronizing")
-
-
-class MyDDGS(DDGS):
-    def answers(self, keywords: str) -> list[dict[str, str]]:
-        """DuckDuckGo instant answers. Query params: https://duckduckgo.com/params.
-
-        Args:
-            keywords: keywords for query,
-
-        Returns:
-            List of dictionaries with instant answers results.
-
-        Raises:
-            DuckDuckGoSearchException: Base exception for duckduckgo_search errors.
-            RatelimitException: Inherits from DuckDuckGoSearchException, raised for exceeding API request rate limits.
-            TimeoutException: Inherits from DuckDuckGoSearchException, raised for API request timeouts.
-        """
-        assert keywords, "keywords is mandatory"
-
-        payload = {
-            "q": f"what is {keywords}",
-            "format": "json",
-        }
-        try:
-            resp_content = self._get_url("GET", "https://api.duckduckgo.com/", params=payload)
-            if not isinstance(resp_content, bytes) and hasattr(resp_content, "content"):
-                resp_content = resp_content.content
-            page_data = json_loads(resp_content)
-        except DuckDuckGoSearchException as e:
-            print(f"LLM_Web_search | DuckDuckGo instant answer yielded error: {str(e)}")
-            return []
-
-        results = []
-        answer = page_data.get("AbstractText")
-        url = page_data.get("AbstractURL")
-        if answer:
-            results.append(
-                {
-                    "icon": None,
-                    "text": answer,
-                    "topic": None,
-                    "url": url,
-                }
-            )
-
-        return results
 
 
 def filter_similar_embeddings(


### PR DESCRIPTION
This pull request simplifies the project by removing the dependency on the `ddgs` package. Instead, [the approach](https://github.com/oobabooga/text-generation-webui/blob/714f7457133db28700e764eb35f9bc0357d2cc5a/modules/web_search.py#L50) of the main web UI is adopted. This means that by default, all search results are retrieved from Duckduckgo, as originally intended by the project. A drawback is that the number of results per query is limited to 10. If more results per query are desired, one has to use searxng as the search engine.