### PR TITLE
Make it optional to keep results in context

### DIFF
--- a/script.js
+++ b/script.js
@@ -55,5 +55,8 @@ gradio_show_force_search_box.addEventListener('change', function() {
   }
 });
 
+var keep_results_checkbox = document.getElementById("keep-results-checkbox");
+keep_results_checkbox.insertAdjacentElement("afterend", keep_results_checkbox.children[1]);
+
 const event = new Event("change");
 gradio_show_force_search_box.dispatchEvent(event);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,13 @@
+.settings-checkbox > label > input[disabled] {
+    opacity: .6;
+    filter: grayscale(100%);
+}
+
+.settings-checkbox > label.disabled > span {
+    color: #525252;
+    opacity: .6;
+}
+
+#first-separator {
+    margin-top: -10px;
+}


### PR DESCRIPTION
While keeping results in context is very useful for asking follow-up questions, it can also quickly fill up the context if several consecutive searches are performed. This PR therefore adds the option to discard search results after each chat-turn, if "Display search results in chat" is disabled.  
This option has no effect for web searches performed while "thinking", since all chains-of-thought/reasoning traces/thinking blocks  are already discarded after each chat turn.

Since the "Force web search" checkbox is rarely needed with current-gen LLMs,  the toggle to show/hide it is moved to the bottom  of the advanced settings and in its place, the new "Keep previous search results in context" checkbox is added.

This PR also includes a minor tweak to the advanced settings, where the disclaimer has been removed and the two options regarding the number of search results to process and the max. number of results to return have now been placed in one row.